### PR TITLE
Bump OFF TK in build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   noarch: python
-  number: 2
+  number: 3
   entry_points:
     - openfe = openfecli.cli:main
   script: {{ PYTHON }} -m pip install . -vv --no-deps
@@ -34,7 +34,7 @@ requirements:
     - networkx
     - numpy
     - openfe-analysis ~=0.2.0
-    - openff-toolkit >=0.13,<0.16
+    - openff-toolkit >=0.13,<0.17
     - openmm !=8.1.0
     - openmmforcefields <0.15
     - openmmtools ~=0.23.0


### PR DESCRIPTION
We regularly test on 0.16.2 in CI. I propose we bump the pin to <0.17.